### PR TITLE
[ENG-2912] Remove cost factor optimization validation

### DIFF
--- a/fero/analysis.py
+++ b/fero/analysis.py
@@ -186,21 +186,6 @@ class CostOptimizeGoal(BaseGoalSchema):
     type = fields.String(validate=validate.OneOf(["COST"]), required=True)
     cost_function = fields.Nested(CostSchema, many=True, required=True)
 
-    @validates_schema
-    def max_functions(self, data: dict, **kwargs):
-        """Validate that there are no more than three cost functions in the `data`.
-
-        :raises ValidationError: when there are more than three cost functions specified in `data`
-        """
-        if len(data["cost_function"]) > 3:
-            raise ValidationError(
-                {
-                    "cost_function": [
-                        "No more than three factors allowed in the cost function."
-                    ]
-                }
-            )
-
 
 class Prediction:
     """Represents the results of a prediction submitted to Fero.


### PR DESCRIPTION
Allow the cost factor length validation to surface from the backend instead. Now that it is no longer limited here, whether 3 or 5 factors is allowed for a cost optimization depends on if the `allowAdaptiveGrid` feature flag is enabled for a company.