### PR TITLE
Feature/ted/eng 3157/combo constraints

### DIFF
--- a/fero/analysis.py
+++ b/fero/analysis.py
@@ -190,12 +190,16 @@ class CostOptimizeGoal(BaseGoalSchema):
 
 
 class CombinationConstraintOperandType(Enum):
+    """An enum listing all valid types of Combination Constraint Operands"""
+
     FORMULA = "formula"
     CONSTANT = "constant"
     COLUMN = "column"
 
 
 class CombinationConstraintOperator(Enum):
+    """An enum listing all valid types of Combination Constraint Operators"""
+
     GREATER_THAN = ">"
     GREATER_THAN_OR_EQUAL = ">="
     LESS_THAN = "<"
@@ -205,6 +209,8 @@ class CombinationConstraintOperator(Enum):
 
 
 class CombinationConstraint(object):
+    """A class to facilitate structuring additional optimization constraints. See README for details."""
+
     _operand_a: Tuple[Union[str, int, float], CombinationConstraintOperandType]
     _operator: CombinationConstraintOperator
     _operand_b: Tuple[Union[str, int, float], CombinationConstraintOperandType]
@@ -215,11 +221,19 @@ class CombinationConstraint(object):
         operator: CombinationConstraintOperator,
         operand_b: Tuple[Union[str, int, float], CombinationConstraintOperandType],
     ):
+        """
+        Create a `Combination Constraint` with two provided operands and an operator.
+
+        :param operand_a: A tuple with the first operand's value and type. (Left side of operator).
+        :param operator: Enum value indicating which a supported operation for the operands.
+        :param operand_b: A tuple with the second operand's value and type. (Right side of operator).
+        """
         self._operand_a = operand_a
         self._operand_b = operand_b
         self._operator = operator
 
-    def dump_combination_constraint(self):
+    def combination_constraint_to_dict(self):
+        """Return valid dictionary representation of this constraint."""
         a_value, a_kind = self._operand_a
         b_value, b_kind = self._operand_b
         return {
@@ -232,6 +246,10 @@ class CombinationConstraint(object):
         }
 
     def verify_combination_constraint(self, analysis):
+        """Basic confirmation that literal column references are valid for this analysis.
+
+        Formula verification occurs on Fero's servers. Any errors will be provided in optimization results.
+        """
         for [value, kind] in [self._operand_a, self._operand_b]:
             if kind == CombinationConstraintOperandType.COLUMN:
                 if value not in analysis.all_factor_names:
@@ -817,7 +835,7 @@ class Analysis(FeroObject):
             "linearFunctionDefinitions": {},
             "combinationConstraints": {
                 "conditions": [
-                    constraint.dump_combination_constraint()
+                    constraint.combination_constraint_to_dict()
                     for constraint in combination_constraints
                 ],
                 "join": "AND",

--- a/fero/analysis.py
+++ b/fero/analysis.py
@@ -190,7 +190,7 @@ class CostOptimizeGoal(BaseGoalSchema):
 
 
 class CombinationConstraintOperandType(Enum):
-    """An enum listing all valid types of Combination Constraint Operands"""
+    """An enum listing all valid types of Combination Constraint Operands."""
 
     FORMULA = "formula"
     CONSTANT = "constant"
@@ -198,7 +198,7 @@ class CombinationConstraintOperandType(Enum):
 
 
 class CombinationConstraintOperator(Enum):
-    """An enum listing all valid types of Combination Constraint Operators"""
+    """An enum listing all valid types of Combination Constraint Operators."""
 
     GREATER_THAN = ">"
     GREATER_THAN_OR_EQUAL = ">="
@@ -246,7 +246,7 @@ class CombinationConstraint(object):
         }
 
     def verify_combination_constraint(self, analysis):
-        """Basic confirmation that literal column references are valid for this analysis.
+        """Check that literal column references are valid for this analysis.
 
         Formula verification occurs on Fero's servers. Any errors will be provided in optimization results.
         """
@@ -256,10 +256,6 @@ class CombinationConstraint(object):
                     raise FeroError(
                         f'"{value}" is not a recognized factor in this analysis'
                     )
-
-
-def join_combination_constraints_with_and(constraints: List[dict]) -> dict:
-    return {"conditions": constraints, "join": "AND", "kind": "clause"}
 
 
 class Prediction:
@@ -525,9 +521,6 @@ class Analysis(FeroObject):
             d
             for d in self._presentation_data["data"]
             if d["id"] == "regression_simulator"
-        )
-        factor_data = next(
-            d for d in self._presentation_data["data"] if d["id"] == "factor_report"
         )
         self._reg_factors = reg_data["content"]["factors"]
         self._reg_targets = reg_data["content"]["targets"]

--- a/fero/analysis.py
+++ b/fero/analysis.py
@@ -826,16 +826,17 @@ class Analysis(FeroObject):
             ],
             "basisSpecifiedColumns": [],
             "linearFunctionDefinitions": {},
-            "combinationConstraints": {
+            "useAdaptiveGrid": kwargs.get("use_adaptive", False),
+        }
+        if combination_constraints is not None and len(combination_constraints) > 0:
+            input_data["combinationConstraints"] = {
                 "conditions": [
                     constraint.combination_constraint_to_dict()
                     for constraint in combination_constraints
                 ],
                 "join": "AND",
                 "kind": "clause",
-            },
-            "useAdaptiveGrid": kwargs.get("use_adaptive", False),
-        }
+            }
         basis_values = self._get_basis_values()
         basis_values.update(fixed_factors)
         input_data["basisValues"] = basis_values

--- a/fero/analysis.py
+++ b/fero/analysis.py
@@ -208,12 +208,8 @@ class CombinationConstraintOperator(Enum):
     NOT_EQUAL = "!="
 
 
-class CombinationConstraint(object):
+class CombinationConstraint:
     """A class to facilitate structuring additional optimization constraints. See README for details."""
-
-    _operand_a: Tuple[Union[str, int, float], CombinationConstraintOperandType]
-    _operator: CombinationConstraintOperator
-    _operand_b: Tuple[Union[str, int, float], CombinationConstraintOperandType]
 
     def __init__(
         self,
@@ -986,57 +982,6 @@ class Analysis(FeroObject):
         By default this function will block until the optimization is complete, however specifying `synchonous=False`
         will instead return a prediction object referencing the optimization being made. This prediction will not contain
         results until the `complete` property is true.
-
-        The expected config input looks as follows:
-
-        Example configuration for a standard (without cost) optimization::
-
-            {
-                "goal": "maximize",
-                "factor": {"name": "factor1", "min": 5, "max": 10}
-            }
-
-        Example configuration for a cost optimization::
-        Cost Goal Config
-        ::
-
-            {
-                "type": "COST",
-                "goal": "minimize"
-                "cost_function": [
-                    {"min": 5, "max": 10, "cost": 1000, "name": "factor1"},
-                    {"min": 5, "max": 10, "cost": 500,  "name": "target2"}
-                ]
-            }
-
-        The constraints configuration is a list of factors and their constraints::
-
-            [
-                {"name": "factor2",  "min": 10, "max": 10}
-                {"name": "target1", "min": 100, "max": 500}
-            ]
-
-        The combination constraints are a list of additional constraints composed of basic arithmetic and boolean operations::
-        Use helper class CombinationConstraint and Enums to help construct combination constraints:
-        `CombinationConstraint`, `CombinationConstraintOperandType`, `CombinationConstraintOperator`::
-
-            [
-                CombinationConstraint(
-                    ("'Int 2' / 'Lookup Int 1'", CombinationConstraintOperandType.FORMULA),
-                    (3, CombinationConstraintOperandType.CONSTANT),
-                    CombinationConstraintOperator.LESS_THAN,
-                ),
-                CombinationConstraint(
-                    ("'Target 1 (Mean)' + 1", CombinationConstraintOperandType.FORMULA),
-                    (131.0, CombinationConstraintOperandType.CONSTANT),
-                    CombinationConstraintOperator.LESS_THAN,
-                ),
-                CombinationConstraint(
-                    ("abs('Int 2' + 'Other')", CombinationConstraintOperandType.FORMULA),
-                    ("Other", CombinationConstraintOperandType.COLUMN),
-                    CombinationConstraintOperator.GREATER_THAN,
-                )
-            ]
 
         :param name: Name for this optimization
         :type name: str

--- a/fero/analysis.py
+++ b/fero/analysis.py
@@ -206,14 +206,14 @@ class CombinationConstraintOperator(Enum):
 
 class CombinationConstraint(object):
     _operand_a: Tuple[Union[str, int, float], CombinationConstraintOperandType]
-    _operand_b: Tuple[Union[str, int, float], CombinationConstraintOperandType]
     _operator: CombinationConstraintOperator
+    _operand_b: Tuple[Union[str, int, float], CombinationConstraintOperandType]
 
     def __init__(
         self,
         operand_a: Tuple[Union[str, int, float], CombinationConstraintOperandType],
-        operand_b: Tuple[Union[str, int, float], CombinationConstraintOperandType],
         operator: CombinationConstraintOperator,
+        operand_b: Tuple[Union[str, int, float], CombinationConstraintOperandType],
     ):
         self._operand_a = operand_a
         self._operand_b = operand_b

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -168,6 +168,8 @@ def expected_optimization_config():
 def expected_optimization_config_with_combination_constraint(
     expected_optimization_config,
 ):
+    """Add a combination constraint to the sample optimization config."""
+
     config = {**expected_optimization_config}
     config["input_data"]["combinationConstraints"] = {
         "conditions": [

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -6,7 +6,13 @@ from uuid import uuid4
 import pytest
 from fero import FeroError
 from unittest import mock
-from fero.analysis import Analysis, Prediction
+from fero.analysis import (
+    Analysis,
+    Prediction,
+    CombinationConstraint,
+    CombinationConstraintOperandType as operands,
+    CombinationConstraintOperator as operators,
+)
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -156,6 +162,31 @@ def expected_optimization_config():
             ],
         },
     }
+
+
+@pytest.fixture
+def expected_optimization_config_with_combination_constraint(
+    expected_optimization_config,
+):
+    config = {**expected_optimization_config}
+    config["input_data"]["combinationConstraints"] = {
+        "conditions": [
+            {
+                "kind": "condition",
+                "target": {
+                    "value": "'Factor 1' + 'Factor 2'",
+                    "kind": "formula",
+                },
+                "operation": {
+                    "operator": ">",
+                    "operand": {"kind": "constant", "value": 150.0},
+                },
+            }
+        ],
+        "join": "AND",
+        "kind": "clause",
+    }
+    return config
 
 
 @pytest.fixture
@@ -725,8 +756,34 @@ def test_make_optimization_type_cost_categorical_function(test_analysis_with_dat
         )
 
 
+def test_make_optimization_combination_constraint_unknown_column(
+    test_analysis_with_data,
+):
+    """Test that a combination constraint raises a Fero Error if it references an unknown column."""
+    with pytest.raises(FeroError):
+        test_analysis_with_data.make_optimization(
+            "test optimization",
+            {
+                "goal": "maximize",
+                "factor": {"name": "Factor 2", "min": 70.0, "max": 100.0},
+            },
+            [
+                {"name": "Factor 1", "min": 60.0, "max": 200.0},
+                {"name": "Target 1", "min": 600.0, "max": 700.0},
+            ],
+            include_confidence_intervals=False,
+            combination_constraints=[
+                CombinationConstraint(
+                    ("'Factor 1' + 'Factor 2'", operands.FORMULA),
+                    operators.GREATER_THAN,
+                    ("Unknown Column", operands.COLUMN),
+                )
+            ],
+        )
+
+
 def test_analysis_make_optimization_simple_case(
-    test_analysis_with_data, expected_optimization_config
+    test_analysis_with_data, expected_optimization_config_with_combination_constraint
 ):
     """Test that make_optimzation makes expected requests and returns a prediction."""
     pred = test_analysis_with_data.make_optimization(
@@ -740,12 +797,22 @@ def test_analysis_make_optimization_simple_case(
             {"name": "Target 1", "min": 600.0, "max": 700.0},
         ],
         include_confidence_intervals=False,
+        combination_constraints=[
+            CombinationConstraint(
+                ("'Factor 1' + 'Factor 2'", operands.FORMULA),
+                operators.GREATER_THAN,
+                (150.0, operands.CONSTANT),
+            )
+        ],
     )
 
     assert pred.result_id == "f0123ab1-c6f4-4bd1-b1a6-02896ba57fc7"
     test_analysis_with_data._client.post.assert_called_with(
         f"/api/analyses/{str(test_analysis_with_data.uuid)}/workspaces/",
-        {"request": expected_optimization_config, "visible": False},
+        {
+            "request": expected_optimization_config_with_combination_constraint,
+            "visible": False,
+        },
     )
     test_analysis_with_data._client.get.assert_called()
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -169,7 +169,6 @@ def expected_optimization_config_with_combination_constraint(
     expected_optimization_config,
 ):
     """Add a combination constraint to the sample optimization config."""
-
     config = {**expected_optimization_config}
     config["input_data"]["combinationConstraints"] = {
         "conditions": [


### PR DESCRIPTION
Fixes [ENG-3157](https://ferolabs.atlassian.net/browse/ENG-3157)

## Change Description
 - Add methods to generate combination constraint structures.
 - Pass them through to backend. (backend surfaces formula issues)
 - Allow fixed factors to take any column available to the Analysis (Combo Constraints may address random non-model fixed factors and need a value in the basis row.)
 - Updates readme with example code


[ENG-3157]: https://ferolabs.atlassian.net/browse/ENG-3157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ