### PR TITLE
Fix _azure_upload crash with binary-mode file objects

### DIFF
--- a/fero/client.py
+++ b/fero/client.py
@@ -192,7 +192,10 @@ class Fero:
         blob_client = BlobClient.from_blob_url(
             f"https://{inbox_response['storage_name']}.blob.core.windows.net/{inbox_response['container']}/{inbox_response['blob']}?{inbox_response['sas_token']}"
         )
-        blob_client.upload_blob(io.BytesIO(fp.read().encode()))
+        data = fp.read()
+        if isinstance(data, str):
+            data = data.encode()
+        blob_client.upload_blob(io.BytesIO(data))
 
     def _paginated_get(
         self, url: str, object_class: Type[FeroObject], params: Dict[str, str]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import pathlib
 here = pathlib.Path(__file__).parent.resolve()
 
 long_description = (here / "README.md").read_text(encoding="utf-8")
-VERSION = "2.2.9"
+VERSION = "2.2.10"
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
## Summary
- Fixes [Sentry: AttributeError: 'bytes' object has no attribute 'encode'](https://fero-labs.sentry.io/issues/7347873415/)
- `_azure_upload` calls `fp.read().encode()`, but when `fp` is opened in binary mode (e.g. `NamedTemporaryFile()`), `.read()` returns `bytes` which has no `.encode()` method
- Called from `run_fixtures` → `install_data_sources` which passes a binary-mode `NamedTemporaryFile`
- Fix handles both `str` and `bytes` inputs

## Test plan
- [ ] `run_fixtures` cronjob completes without this error after deploying updated fero client