### PR TITLE
Fix: create GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     needs: lint-and-test
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -55,3 +55,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            dist/*


### PR DESCRIPTION
## Summary
- The release workflow published to PyPI but never created a GitHub Release
- Adds a `gh release create` step after PyPI publish with `--generate-notes` and dist artifacts attached
- Upgrades `permissions.contents` from `read` to `write` so the workflow can create releases

## Test plan
- [ ] Push a test tag (e.g., on a fork) to verify the release is created
- [ ] Verify PyPI publish still works as before
- [ ] Optionally: manually publish the existing draft v2.2.10 release