### PR TITLE
Update flake8 to 7.3.0 to fix mccabe dependency conflict

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,7 +24,7 @@ docutils==0.23
     # via
     #   readme-renderer
     #   restructuredtext-lint
-flake8==4.0.1
+flake8==7.3.0
     # via
     #   -r dev-requirements.in
     #   flake8-docstrings
@@ -45,7 +45,7 @@ jeepney==0.9.0
     #   secretstorage
 keyring==23.6.0
     # via twine
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
 mypy-extensions==0.4.4
     # via black
@@ -61,13 +61,13 @@ platformdirs==2.5.2
     # via black
 pluggy==1.6.0
     # via pytest
-pycodestyle==2.8.0
+pycodestyle==2.14.0
     # via flake8
 pycparser==2.21
     # via cffi
 pydocstyle==6.1.1
     # via flake8-docstrings
-pyflakes==2.4.0
+pyflakes==3.4.0
     # via flake8
 pygments==2.20.0
     # via


### PR DESCRIPTION
Renovate bumped mccabe to 0.7.0 but flake8 4.0.1 requires mccabe <0.7.0. This upgrades flake8 and its sub-dependencies (pycodestyle, pyflakes) to compatible versions. No new lint errors introduced.