### PR TITLE
Release 2.2.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import pathlib
 here = pathlib.Path(__file__).parent.resolve()
 
 long_description = (here / "README.md").read_text(encoding="utf-8")
-VERSION = "2.2.13"
+VERSION = "2.2.14"
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
Bumps `VERSION` to 2.2.14 so a release can be cut from `main`.

`main` has merged dependency-pin widenings since v2.2.13 (marshmallow → `>=3.13,<5`, pyarrow → `>=19`) but hasn't been released. This version bump lets a `v2.2.14` tag pass `setup.py verify` and publish to PyPI.

Version-only change.