### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import pathlib
 here = pathlib.Path(__file__).parent.resolve()
 
 long_description = (here / "README.md").read_text(encoding="utf-8")
-VERSION = "2.2.13"
+VERSION = "2.3.0"
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
Release the packaging/dependency changes from #197 as a new client version.

- `VERSION` 2.2.13 -> 2.3.0

Minor bump: widened dependency ranges (`marshmallow>=3.13,<5`, `pyarrow>=19`), dropped the unused `oauthlib` and `pydantic-settings`, and moved to a setup.py-driven pip-compile layout. No public API changes.

After merge, push the `v2.3.0` tag on main to trigger the PyPI release workflow.