### PR TITLE
Fix release: verify tag against built artifact instead of setup.py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # Publishes to PyPI when a version tag is pushed.
 # Repository secret: PYPI_API_TOKEN (PyPI → Account settings → API tokens).
-# setup.py verify reads GITHUB_REF_NAME — set automatically by GitHub Actions for the ref that triggered the run.
+# The build step verifies the tag matches the package version via GITHUB_REF_NAME — set automatically by GitHub Actions for the ref that triggered the run.
 
 name: Release
 
@@ -47,10 +47,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r dev-requirements.txt build
-      - name: Verify Git tag matches package version
-        run: python setup.py verify
       - name: Build sdist and wheel
         run: python -m build
+      - name: Verify Git tag matches built version
+        run: |
+          expected="fero-${GITHUB_REF_NAME#v}.tar.gz"
+          if [ ! -f "dist/$expected" ]; then
+            echo "Built artifacts do not match tag ${GITHUB_REF_NAME}: expected dist/$expected"
+            ls -1 dist
+            exit 1
+          fi
+          echo "OK: $expected"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,12 @@
 """File to define installation of the `fero` package."""
 
-import os
-import sys
-
-
 from setuptools import setup
-from setuptools.command.install import install
 import pathlib
 
 here = pathlib.Path(__file__).parent.resolve()
 
 long_description = (here / "README.md").read_text(encoding="utf-8")
 VERSION = "2.3.0"
-
-
-class VerifyVersionCommand(install):
-    """Custom command to verify that the git tag matches our version."""
-
-    description = "verify that the git tag matches our version"
-
-    def run(self):
-        """Verify that the git tag matches our version with this custom command."""
-        tag = os.getenv("CIRCLE_TAG") or os.getenv("GITHUB_REF_NAME")
-        if not tag:
-            sys.exit(
-                "Set CIRCLE_TAG or GITHUB_REF_NAME to the release tag (e.g. v1.2.3) to verify."
-            )
-        if tag.lstrip("v") != VERSION:
-            info = f"Git tag: {tag} does not match the version of this app: {VERSION}"
-            sys.exit(info)
 
 
 setup(
@@ -73,8 +51,5 @@ setup(
     project_urls={
         "Bug Reports": "https://github.com/pypa/sampleproject/issues",
         "Source": "https://github.com/pypa/sampleproject/",
-    },
-    cmdclass={
-        "verify": VerifyVersionCommand,
     },
 )


### PR DESCRIPTION
The 2.3.0 release ([run](https://github.com/FeroLabs/fero_client/actions/runs/30023409215)) failed at the **Verify Git tag** step with `ModuleNotFoundError: No module named 'setuptools'`.

## Cause
The rebase moved CI to Python 3.14, which no longer bundles `setuptools`. The publish job ran `python setup.py verify`, which imports setuptools at module load — so it failed before build/publish. (Nothing was published to PyPI.)

## Fix
- Reorder the publish job to **build first, then verify** the git tag matches the produced sdist (`fero-<version>.tar.gz`). `python -m build` uses an isolated PEP 517 env, so no setuptools is needed in the runner, and the deprecated `setup.py` command interface is no longer used.
- Remove the now-dead `VerifyVersionCommand` (and its `os`/`sys`/`install` imports) from setup.py.

Verified locally: build produces `fero-2.3.0.tar.gz`; the check passes for tag `v2.3.0` and correctly fails for a mismatched tag.