### PR TITLE
Make GitHub Release step idempotent for UI-created releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,16 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes \
-            dist/*
+          # The run may be triggered by a raw tag push (no release yet) or by
+          # publishing a release from the UI (tag + release already exist), so
+          # handle both: attach the built artifacts either way.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes dist/*
+          fi


### PR DESCRIPTION
Follow-up to #208. The 2.3.0 publish ([run](https://github.com/FeroLabs/fero_client/actions/runs/30024881052)) succeeded through **Publish to PyPI** (2.3.0 is live), but the final **Create GitHub Release** step failed: `a release with the same tag name already exists: v2.3.0`.

## Cause
The workflow triggers on tag push, but publishing a release from the GitHub UI *also* pushes the tag — so by the time the job runs, the tag and release already exist, and `gh release create` refuses to overwrite.

## Fix
Detect an existing release and `gh release upload --clobber` the built artifacts to it; otherwise create it as before. Now the workflow works whether the release is cut via a raw tag push or the UI.

_No action needed for 2.3.0 itself — it is already on PyPI._